### PR TITLE
add disk usage link on top level sidemenu

### DIFF
--- a/src/main/java/hudson/plugins/disk_usage/DiskUsagePlugin.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsagePlugin.java
@@ -7,6 +7,8 @@ import hudson.model.AbstractProject;
 import hudson.model.Hudson;
 import hudson.model.Job;
 import hudson.model.ManagementLink;
+import hudson.model.RootAction;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
@@ -29,7 +31,7 @@ public class DiskUsagePlugin extends Plugin {
     private static DiskUsage diskUsageSum;
 
     @Extension
-    public static class DiskUsageManagementLink extends ManagementLink {
+    public static class DiskUsageManagementLink extends ManagementLink implements RootAction {
 
         public final String[] COLUMNS = new String[]{"Project name", "Builds", "Workspace"};
 


### PR DESCRIPTION
as /manage is restricted to admins, disk-usage isn't accessible to build manager, but very useful to check disk consumption for a set of job, so they have to bookmark the URL.
This change adds the link to top-level sidemenu, so that it gets available to anyone on jenkins
