### PR TITLE
Calculation disk usage of build after its completion and add time out for calculation disk usage of workspace

### DIFF
--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageBuildListener.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageBuildListener.java
@@ -1,0 +1,28 @@
+package hudson.plugins.disk_usage;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Build listener for calculation build disk usage
+ * 
+ * @author Lucie Votypkova
+ */
+@Extension
+public class DiskUsageBuildListener extends RunListener<AbstractBuild>{
+    
+    @Override
+    public void onCompleted(AbstractBuild build, TaskListener listener){
+        try{
+                DiskUsageThread.calculateDiskUsageForBuild(build);
+        }
+        catch(Exception ex){
+            listener.getLogger().println("Disk usage plugin fails during calculation disk usage of this build.");
+                Logger.getLogger(getClass().getName()).log(Level.WARNING, "Disk usage plugin fails during build calculation disk space of job " + build.getParent().getDisplayName(), ex);
+        }
+    }
+}


### PR DESCRIPTION
I add time out for calculation of workspace due to situation in which there is something wrong with slave and it stops communicate during waiting for result and Jenkins  does not recognize it.
