### PR TITLE
Should use last build workspace, not just "some" workspace.

### DIFF
--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageThread.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageThread.java
@@ -7,16 +7,9 @@ import hudson.matrix.MatrixProject;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenModuleSet;
 import hudson.maven.MavenModuleSetBuild;
-import hudson.model.AsyncPeriodicWork;
-import hudson.model.Item;
-import hudson.model.ItemGroup;
-import hudson.model.TaskListener;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Hudson;
+import hudson.model.*;
 import hudson.remoting.Callable;
 
-import hudson.remoting.Channel;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -141,7 +134,7 @@ public class DiskUsageThread extends AsyncPeriodicWork {
                 lastBuild.addAction(bdua);
                 updateWs = true;
             }
-            FilePath workspace = project.getSomeWorkspace();
+            FilePath workspace = lastBuild.getWorkspace();
             //slave might be offline...or have been deleted - set to 0
             if (workspace != null) {
             	long oldWsUsage = bdua.diskUsage.wsUsage;


### PR DESCRIPTION
According to javadoc http://javadoc.jenkins-ci.org/hudson/model/AbstractProject.html#getSomeWorkspace%28%29 getSomeWorkspace returns "a workspace for some build of this project", but we actually need the workspace of the last build. That matters, when you have several nodes where the job has run.
