### PR TITLE
Configure time out for calculation disk usage of workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 work
 *.iml
 .DS_Store
+.idea

--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageProjectActionFactory.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageProjectActionFactory.java
@@ -41,6 +41,9 @@ public class DiskUsageProjectActionFactory extends TransientProjectActionFactory
 		// Number of days in history
         private int historyLength = 183;
 
+        // Timeout for a single Project's workspace analyze (in mn)
+        private int timeoutWorkspace = 5;
+
 		List<DiskUsageOvearallGraphGenerator.DiskUsageRecord> history = new LinkedList<DiskUsageOvearallGraphGenerator.DiskUsageRecord>(){
 				private static final long serialVersionUID = 1L;
 
@@ -67,7 +70,10 @@ public class DiskUsageProjectActionFactory extends TransientProjectActionFactory
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            // Configure showGraph
             showGraph = req.getParameter("disk_usage.showGraph") != null;
+
+            // Configure historyLength
 			String histlen = req.getParameter("disk_usage.historyLength");
 			if(histlen != null ){
 				try{
@@ -78,6 +84,18 @@ public class DiskUsageProjectActionFactory extends TransientProjectActionFactory
 			}else{
 				historyLength = 183;
 			}
+
+            // Configure timeoutWorkspace
+            String timeoutWks = req.getParameter("disk_usage.timeoutWorkspace");
+            if (timeoutWks != null ) {
+                try {
+                    timeoutWorkspace = Integer.parseInt(timeoutWks);
+                } catch (NumberFormatException ex) {
+                    timeoutWorkspace = 5;
+                }
+            } else {
+                timeoutWorkspace = 5;
+            }
             save();
             return super.configure(req, formData);
         }
@@ -97,6 +115,14 @@ public class DiskUsageProjectActionFactory extends TransientProjectActionFactory
 
         public void setHistoryLength(Integer historyLength) {
             this.historyLength = historyLength;
+        }
+
+        public int getTimeoutWorkspace() {
+            return timeoutWorkspace;
+        }
+
+        public void setTimeoutWorkspace(Integer timeoutWorkspace) {
+            this.timeoutWorkspace = timeoutWorkspace;
         }
     }
 

--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageThread.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageThread.java
@@ -30,7 +30,7 @@ public class DiskUsageThread extends AsyncPeriodicWork {
     //trigger disk usage thread each 6 hours
     public static final int COUNT_INTERVAL_MINUTES = 60*6;
     
-    public static final int WORKSPACE_TIMEOUT = 1000*60*5;
+    public static final int WORKSPACE_TIMEOUT = 1000*60*DiskUsageProjectActionFactory.DESCRIPTOR.getTimeoutWorkspace();
 
 
     public DiskUsageThread() {

--- a/src/main/resources/hudson/plugins/disk_usage/DiskUsageProjectActionFactory/global.jelly
+++ b/src/main/resources/hudson/plugins/disk_usage/DiskUsageProjectActionFactory/global.jelly
@@ -9,5 +9,10 @@
           ${%OverallGraphHistoryLength}
 	      <f:textbox name="disk_usage.historyLength" value="${descriptor.historyLength}" />
       </f:entry>
+
+      <f:entry title="">
+                ${%TimeoutWorkspace}
+      	      <f:textbox name="disk_usage.timeoutWorkspace" value="${descriptor.timeoutWorkspace}" />
+            </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/disk_usage/DiskUsageProjectActionFactory/global.properties
+++ b/src/main/resources/hudson/plugins/disk_usage/DiskUsageProjectActionFactory/global.properties
@@ -21,3 +21,4 @@
 # THE SOFTWARE.
 
 OverallGraphHistoryLength=Overall graph history length (days)
+TimeoutWorkspace=Timeout to calculate size for a single project's workspace (minutes).

--- a/src/main/resources/hudson/plugins/disk_usage/DiskUsageProjectActionFactory/global_fr.properties
+++ b/src/main/resources/hudson/plugins/disk_usage/DiskUsageProjectActionFactory/global_fr.properties
@@ -23,3 +23,4 @@
 Disk\ usage=Utilisation du disque
 Show\ disk\ usage\ trend\ graph\ on\ the\ project\ page=Montrer le graphique de tendance d''utilisation du disque sur la page du projet
 OverallGraphHistoryLength=Taille du graphique d''historique (jours)
+TimeoutWorkspace=Timeout pour calculer l''espace disque d''un workspace d''un projet (minutes).


### PR DESCRIPTION
Add global option to configure the time out for calculation disk usage of workspace (useful for huge projects on slow disks).
