### PR TITLE
Fix deadlock DiskUsageProperty / ProjectDiskUsage

### DIFF
--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageProperty.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageProperty.java
@@ -447,11 +447,11 @@ public class DiskUsageProperty extends JobProperty<Job<?, ?>> {
         }
     }    
 
-    public synchronized void saveDiskUsage() {
+    public void saveDiskUsage() {
         diskUsage.save();
     }
     
-    public synchronized void loadDiskUsage(){
+    public void loadDiskUsage(){
         diskUsage.load();        
     }
 


### PR DESCRIPTION
Fix the following deadlock:

```
"Calculation of workspace usage thread":
	at hudson.plugins.disk_usage.ProjectDiskUsage.save(ProjectDiskUsage.java:68)
	- waiting to lock <0x00000000ee7eb738> (a hudson.plugins.disk_usage.ProjectDiskUsage)
	at hudson.plugins.disk_usage.DiskUsageProperty.saveDiskUsage(DiskUsageProperty.java:451)
	- locked <0x00000000ee7eb718> (a hudson.plugins.disk_usage.DiskUsageProperty)
	at hudson.plugins.disk_usage.DiskUsageProperty.putSlaveWorkspaceSize(DiskUsageProperty.java:183)
	at hudson.plugins.disk_usage.DiskUsageUtil.calculateWorkspaceDiskUsage(DiskUsageUtil.java:486)
	at hudson.plugins.disk_usage.WorkspaceDiskUsageCalculationThread.execute(WorkspaceDiskUsageCalculationThread.java:51)
	at hudson.model.AsyncAperiodicWork$1.run(AsyncAperiodicWork.java:76)
	at java.lang.Thread.run(Thread.java:745)
"Calculation of job directories (without builds) thread":
	at hudson.plugins.disk_usage.DiskUsageProperty.saveDiskUsage(DiskUsageProperty.java:451)
	- waiting to lock <0x00000000ee7eb718> (a hudson.plugins.disk_usage.DiskUsageProperty)
	at hudson.plugins.disk_usage.DiskUsageProperty.checkWorkspaces(DiskUsageProperty.java:318)
	at hudson.plugins.disk_usage.ProjectDiskUsage.loadFirstTime(ProjectDiskUsage.java:102)
	- locked <0x00000000ee7eb738> (a hudson.plugins.disk_usage.ProjectDiskUsage)
	at hudson.plugins.disk_usage.DiskUsageUtil.loadData(DiskUsageUtil.java:85)
	at hudson.plugins.disk_usage.DiskUsageUtil.addProperty(DiskUsageUtil.java:64)
	at hudson.plugins.disk_usage.ProjectDiskUsageAction.getBuildsInformation(ProjectDiskUsageAction.java:281)
	at hudson.plugins.disk_usage.DiskUsageUtil.calculateDiskUsageForProject(DiskUsageUtil.java:313)
	at hudson.plugins.disk_usage.JobWithoutBuildsDiskUsageCalculation.execute(JobWithoutBuildsDiskUsageCalculation.java:52)
	at hudson.model.AsyncAperiodicWork$1.run(AsyncAperiodicWork.java:76)
	at java.lang.Thread.run(Thread.java:745)
```

The ressource to protect is really `ProjectDiskUsage`, whose `load()` and `save()` methods are already synchronized.
Having additionnal synchronization on a `DiskUsageProperty` instance around calls to `ProjectDiskUsage.load()` and `ProjectDiskUsage.save()` seems useless, and is what leads to the above deadlock.
This commit simply removes this extra synchronisation from `DiskUsageProperty`.