### PR TITLE
Fix absolute URL (links and redirect)

### DIFF
--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageManagement.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageManagement.java
@@ -40,7 +40,7 @@ public class DiskUsageManagement extends ManagementLink implements RootAction{
         
         public void doIndex(StaplerRequest req, StaplerResponse res) throws ServletException, IOException{
             DiskUsagePlugin plugin = Jenkins.getInstance().getPlugin(DiskUsagePlugin.class);
-            res.sendRedirect(Jenkins.getInstance().getRootUrl() + "plugin/disk-usage");
+            res.sendRedirect(Jenkins.getInstance().getRootUrlFromRequest() + "plugin/disk-usage");
         }
     
 }

--- a/src/main/java/hudson/plugins/disk_usage/DiskUsagePlugin.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsagePlugin.java
@@ -139,11 +139,6 @@ public class DiskUsagePlugin extends Plugin {
         return DiskUsageUtil.getSizeString(size);
     }
     
-    //Another shortcut
-    public static String getProjectUrl(Job project) {
-        return Util.encode(project.getAbsoluteUrl());
-    }
-    
     /**
      * @return Project list sorted by occupied disk space
      */

--- a/src/main/resources/hudson/plugins/disk_usage/DiskUsagePlugin/index.jelly
+++ b/src/main/resources/hudson/plugins/disk_usage/DiskUsagePlugin/index.jelly
@@ -60,7 +60,7 @@
       <j:set var="buildsLocked" value="0"/>
       <j:forEach var="p" items="${projects}">
         <tr>
-          <td><b><a href="${it.getProjectUrl(p)}">${p.fullDisplayName}</a></b> </td>
+          <td><b><a href="${rootURL}/${p.url}">${p.fullDisplayName}</a></b> </td>
           <j:set var="diskUsage" value="${it.getDiskUsage(p)}" />
            <j:set var="buildDiskUsage" value="${diskUsage.getBuildsDiskUsage(request.getAttribute('older'), request.getAttribute('younger'))}" />            
            <j:set var="buildsAll" value="${buildsAll + buildDiskUsage.get('all')}"/>


### PR DESCRIPTION
The following two patches fix issues with the disk-usage-plugin when Jenkins is hosted behind several reverse proxies, with different IP/hostnames.  
 - the first commit avoid being redirected to a different hostname/IP when click the "Disk usage" link
 - the second commit fix some absolute URL hyperlinks from disk-usage page to jobs pages