### PR TITLE
JENKINS-25716

### DIFF
--- a/src/main/resources/hudson/plugins/disk_usage/ProjectDiskUsageAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/disk_usage/ProjectDiskUsageAction/floatingBox.jelly
@@ -5,7 +5,7 @@ Project disk usage information + trend graph
 
 <j:if test="${(from.getAllDiskUsageWorkspace() > 0) || (from.getJobRootDirDiskUsage() > 0) || (from.getAllBuildsDiskUsage() > 0)}">
     
-  <div style="width:auto;align:right;margin:12px;">
+  <div style="max-width:476px;width:auto;align:right;margin:12px;">
     <div style="width:auto;margin:0px;margin-left:auto;text-align:right;">
       <img src="${resURL}/plugin/disk-usage/icons/diskusage16.png" /> 
      


### PR DESCRIPTION
floatingBox.jelly has no fixed width causes the floating box to fall outside the box model in some cases.  Updated to add max-width 476px (12px + 12px including margins) = 500px max width.

Fixes problem as described here: https://issues.jenkins-ci.org/browse/JENKINS-25716