### PR TITLE
Fix URL on images

### DIFF
--- a/src/main/resources/hudson/plugins/disk_usage/ProjectDiskUsageAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/disk_usage/ProjectDiskUsageAction/jobMain.jelly
@@ -6,32 +6,32 @@
 
                 <table class="fileList">
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Job}</td>
                         <td class="fileSize">${from.getSizeInString(from.getJobRootDirDiskUsage())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%All builds}</td>
                         <td class="fileSize">${from.getSizeInString(from.getBuildsDiskUsage().get('all'))}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Locked builds}</td>
                         <td class="fileSize">${from.getSizeInString(from.getBuildsDiskUsage().get('locked'))}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%All workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllDiskUsageWorkspace())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Slave workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllSlaveWorkspaces())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Non-slave workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllCustomOrNonSlaveWorkspaces())}</td>
                     </tr>


### PR DESCRIPTION
When display a project,, icons before Job, All bilds, Locked builds, All
workspaces, Slave workspaces, Non-slave workspaces have a broken link.

The root URL was missing, add ${resURL} as prefix in the attribute src,
for node img.