### PR TITLE
fix missing icons with non-root webapp context

### DIFF
--- a/src/main/resources/hudson/plugins/disk_usage/ProjectDiskUsageAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/disk_usage/ProjectDiskUsageAction/jobMain.jelly
@@ -6,32 +6,32 @@
 
                 <table class="fileList">
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Job}</td>
                         <td class="fileSize">${from.getSizeInString(from.getJobRootDirDiskUsage())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%All builds}</td>
                         <td class="fileSize">${from.getSizeInString(from.getBuildsDiskUsage().get('all'))}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Locked builds}</td>
                         <td class="fileSize">${from.getSizeInString(from.getBuildsDiskUsage().get('locked'))}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%All workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllDiskUsageWorkspace())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Slave workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllSlaveWorkspaces())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Non-slave workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllCustomOrNonSlaveWorkspaces())}</td>
                     </tr>


### PR DESCRIPTION
Some icons are missing when Jenkins is deployed, for instance, with a "/jenkins/" webapp context.  See here for an explanation:
https://wiki.jenkins-ci.org/display/JENKINS/Hyperlinks+in+HTML
Note that in the same "jobMain.jelly" file, there is also a "`<summary icon='...'>`" (/lib/husdon taglib) with an icon URL, which does not require the ${resURL} prefix. This is because it's already added by the taglib. My changes only affect the pure-HTML "`<img src='...'>`" tags.