### PR TITLE
JENKINS-30934 - remove dubious Thread.sleep(60000)

### DIFF
--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageCalculation.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageCalculation.java
@@ -96,12 +96,6 @@ public abstract class DiskUsageCalculation extends AsyncAperiodicWork{
             getLastTask().cancel();   
         }
         Timer.get().schedule(getNewInstance(), getRecurrencePeriod(), TimeUnit.MILLISECONDS);
-        
-        try {
-            Thread.sleep(60000);
-        } catch (InterruptedException ex) {
-            Logger.getLogger(DiskUsageCalculation.class.getName()).log(Level.SEVERE, null, ex);
-        }
     }
     
     public abstract CronTab getCronTab() throws ANTLRException;


### PR DESCRIPTION
Naive attempt at fixing [JENKINS-30934](https://issues.jenkins-ci.org/browse/JENKINS-30934). I'm still not sure what the intent was for this `Thread.sleep(60000)` call, so it might be completely invalid to simply remove it like this...