### PR TITLE
Add support for programmatically created Pipeline job

### DIFF
--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageProperty.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageProperty.java
@@ -444,7 +444,7 @@ public class DiskUsageProperty extends JobProperty<Job<?, ?>> {
     }
     
     public void loadDiskUsage(){
-        AbstractProject job = (AbstractProject) owner;
+        Job job = (Job) owner;
         diskUsage.load(); 
         //ensure that build was not removed without calling listener - badly removed, or badly saved (without build.xml)
         for(DiskUsageBuildInformation information : diskUsage.getBuildDiskUsage(false)){


### PR DESCRIPTION
When loading disk usage, AbstractProject causes class cast exception for other plugins that create pipeline job programmatically using jenkins.model.Jenkins.createProjectFromXML()
below is Jenkins log for reference:
	at hudson.plugins.disk_usage.DiskUsageProperty.loadDiskUsage(DiskUsageProperty.java:462)
	at hudson.plugins.disk_usage.DiskUsageProperty.setOwner(DiskUsageProperty.java:136)
	at hudson.model.Job.onLoad(Job.java:240)
	at org.jenkinsci.plugins.workflow.job.WorkflowJob.onLoad(WorkflowJob.java:145)
	at hudson.model.Items.load(Items.java:372)
	at hudson.model.ItemGroupMixIn$4.call(ItemGroupMixIn.java:277)
	at hudson.model.ItemGroupMixIn$4.call(ItemGroupMixIn.java:275)
	at hudson.model.Items.whileUpdatingByXml(Items.java:135)
	at hudson.model.ItemGroupMixIn.createProjectFromXML(ItemGroupMixIn.java:275)
	at jenkins.model.Jenkins.createProjectFromXML(Jenkins.java:3859)