### PR TITLE
Fix URL on images

### DIFF
--- a/src/main/resources/hudson/plugins/disk_usage/ProjectDiskUsageAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/disk_usage/ProjectDiskUsageAction/jobMain.jelly
@@ -7,32 +7,32 @@
 
                 <table class="fileList">
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Job}</td>
                         <td class="fileSize">${from.getSizeInString(from.getJobRootDirDiskUsage())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%All builds}</td>
                         <td class="fileSize">${from.getSizeInString(from.getBuildsDiskUsage().get('all'))}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Locked builds}</td>
                         <td class="fileSize">${from.getSizeInString(from.getBuildsDiskUsage().get('locked'))}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%All workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllDiskUsageWorkspace())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Slave workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllSlaveWorkspaces())}</td>
                     </tr>
                     <tr>
-                        <td><img src="/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
+                        <td><img src="${resURL}/plugin/disk-usage/icons/directory16.png" height="16" width="16" alt="Directory icon" /></td>
                         <td>${%Non-slave workspaces}</td>
                         <td class="fileSize">${from.getSizeInString(from.getAllCustomOrNonSlaveWorkspaces())}</td>
                     </tr>


### PR DESCRIPTION
When display a project,, icons before Job, All bilds, Locked builds, All workspaces, Slave workspaces, Non-slave workspaces have a broken link.

The root URL was missing, add ${resURL} as prefix in the attribute src, for node img.

Fixes https://issues.jenkins.io/browse/JENKINS-30830 wrong path in html output to directory16.png

This was already done on #34 but was archived in branch https://github.com/jenkinsci/disk-usage-plugin/tree/master-archive and never released. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

