### PR TITLE
Removes deprecated maven property java.level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <properties>
-    <java.level>11</java.level>
-  </properties>
-
   <dependencies>
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
java.level is no longer the way to set the required java version

https://github.com/jenkinsci/plugin-pom/pull/522

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] ~~Link to relevant issues in GitHub or Jira~~
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
