### PR TITLE
Disk Usage: Add maxDepthDir argument for usage

### DIFF
--- a/src/main/java/hudson/plugins/disk_usage/DiskUsageProjectActionFactory.java
+++ b/src/main/java/hudson/plugins/disk_usage/DiskUsageProjectActionFactory.java
@@ -81,6 +81,7 @@ public class DiskUsageProjectActionFactory extends TransientProjectActionFactory
         private Long diskUsageLockedBuilds = 0L;
 
         private boolean showGraph = true;
+        private int maxDepthDirTraverse = -1;
         private int historyLength = 183;
         List<DiskUsageOvearallGraphGenerator.DiskUsageRecord> history = new LinkedList<DiskUsageOvearallGraphGenerator.DiskUsageRecord>(){
             private static final long serialVersionUID = 1L;
@@ -282,6 +283,15 @@ public class DiskUsageProjectActionFactory extends TransientProjectActionFactory
                 return null;
             }
             return size.split(" ")[0];
+        }
+
+        public int getMaxDepthDirTraverse() {
+            return maxDepthDirTraverse;
+        }
+
+
+        public void setMaxDepthDirTraverse(int depth) {
+            this.maxDepthDirTraverse = depth;
         }
 
 

--- a/src/main/resources/hudson/plugins/disk_usage/DiskUsageProjectActionFactory/global.jelly
+++ b/src/main/resources/hudson/plugins/disk_usage/DiskUsageProjectActionFactory/global.jelly
@@ -132,6 +132,9 @@
     <f:entry title="${%Jobs excluded for disk usage calculation}">
       <f:textarea name="excludedJobs" value="${descriptor.getExcludedJobsInString()}"/>
     </f:entry>
+    <f:entry title="${%Max Depth of Directory Traversal}">
+      <f:textbox name="maxDepthDirTraverse" value="${descriptor.getMaxDepthDirTraverse()}"/>
+    </f:entry>
 
     <!--  </f:section>-->
     <!--     <f:submit name="Submit" value="Submit"/>


### PR DESCRIPTION
Implement a max depth argument for large directories to prevent timeouts

### Testing done

<!-- Comment:
Please help me write unit tests for this - the ones I am writing are causing cascading failures in other tets
-->

```[tasklist]
### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
